### PR TITLE
Handle null vendorTree and fix eslint error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic
 Versioning](http://semver.org/).
 
-## [Unreleased]
+## 1.0.1
+### Changed
+- fixed eslint error re: unused var in `/app/ext/torii-provider-arcgis.js`
+- fixed for Ember 2.18.x build error when vendorTree is null
+
+## 1.0.0
 ### Added
 - support for web-tier authentication
 - `session.authType` with values of `token` or `web-tier`

--- a/app/initializers/torii-provider-arcgis.js
+++ b/app/initializers/torii-provider-arcgis.js
@@ -10,7 +10,7 @@
  * which reopen's the Torii Session, and adds additional methods
  * to it which are useful for ArcGIS Online Sessions
  */
-
+/* eslint no-unused-vars: ["error", { "varsIgnorePattern": "ext" }] */
 import ext from '../ext/torii-provider-arcgis';
 
 export function initialize () {

--- a/index.js
+++ b/index.js
@@ -35,8 +35,11 @@ module.exports = {
       destDir: '@esri/arcgis-rest-auth'
     });
 
-
-    var treesToMerge = [vendorTree, arcgisRequestTree, arcgisAuthTree];
+    var treesToMerge = [arcgisRequestTree, arcgisAuthTree];
+    // if we got a vendorTree, and add it in
+    if (vendorTree) {
+      treesToMerge = [vendorTree, arcgisRequestTree, arcgisAuthTree];
+    }
 
     return new MergeTrees(treesToMerge);
   }


### PR DESCRIPTION
Ran into two errors when using in Hub
- un-used var eslint error 
- build error when `vendotTree` is null

Fixed both and updates changelog