### PR TITLE
Use correct file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic
 Versioning](http://semver.org/).
 
+## 1.0.2
+### Changed
+- include the `request.umd.js` file which is the actual current build output from ArcGIS Rest JS
+
 ## 1.0.1
 ### Changed
 - fixed eslint error re: unused var in `/app/ext/torii-provider-arcgis.js`

--- a/index.js
+++ b/index.js
@@ -25,8 +25,8 @@ module.exports = {
   },
 
   treeForVendor(vendorTree) {
-    var arcgisRequestTree = new Funnel(path.dirname(require.resolve('@esri/arcgis-rest-request/dist/umd/arcgis-rest-request.umd.js')), {
-      files: ['arcgis-rest-request.umd.js', 'arcgis-rest-request.umd.js.map'],
+    var arcgisRequestTree = new Funnel(path.dirname(require.resolve('@esri/arcgis-rest-request/dist/umd/request.umd.js')), {
+      files: ['request.umd.js', 'request.umd.js.map'],
       destDir: '@esri/arcgis-rest-request'
     });
 


### PR DESCRIPTION
the 1.2.0 version of arcgis-rest-request includes two sets of umd output files. The old-and-not-current have `arcgis-rest-` prefixes. Torii needs to include the `request.umd.js` file instead.
