### PR TITLE
Open() on the Adapter should Throw if it can't create a session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic
 Versioning](http://semver.org/).
 
+## 1.1.2
+### Fixed
+- adapter was not but should have been `throw`-ing an exception out of `open`
+
 ## 1.1.1
 ### Fixed
 - removed debugger in `redirect.html`

--- a/app/torii-adapters/arcgis-oauth-bearer.js
+++ b/app/torii-adapters/arcgis-oauth-bearer.js
@@ -119,7 +119,8 @@ export default Ember.Object.extend({
 
     })
     .catch((ex) => {
-      console.error(`${debugPrefix} exception occured ${ex}`);
+      // console.error(`${debugPrefix} exception occured ${ex}`);
+      throw new Error(`${debugPrefix} exception occured ${ex}`);
     });
   },
 


### PR DESCRIPTION
Torii expects the adapter to throw if a setting can't be established for some reason. We were just logging the error in a `.catch`.

In client app, if there was a cookie or prior session in local storage, and the token was for another ENV, or was expired, instead of showing the sign-in route, the app would just explode. Adding this `throw` lets the app (correctly) fall into it's `catch` block which routes to sign-in.