### PR TITLE
match AGOL cookie behavior and create UserSession from cache appropriately.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic
 Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- match behavior of ArcGIS Online cookie, which caches usernames as an `email`.
 
 ## [1.1.5]
 ### Fixed

--- a/app/torii-adapters/arcgis-oauth-bearer.js
+++ b/app/torii-adapters/arcgis-oauth-bearer.js
@@ -251,7 +251,8 @@ export default Ember.Object.extend({
     let portalUrl = this.get('settings').portalUrl + '/sharing/rest';
     let options = {
       clientId: settings.clientId,
-      username: settings.username,
+      // in an ArcGIS Online cookie, the username is tagged as an email.
+      username: settings.username ? settings.username : settings.email,
       token: settings.token,
       tokenDuration: parseInt(settings.expires_in),
       portal: portalUrl
@@ -347,8 +348,8 @@ export default Ember.Object.extend({
       create: sessionInfo.currentUser.created,
       culture: sessionInfo.currentUser.culture,
       customBaseUrl: sessionInfo.portal.customBaseUrl,
-      username: sessionInfo.currentUser.username,
-      email: sessionInfo.currentUser.email,
+      // to mimic the ArcGIS Online cookie, we tag the username as an email.
+      email: sessionInfo.currentUser.username,
       expires: sessionInfo.expires,
       region: sessionInfo.currentUser.region,
       role: sessionInfo.currentUser.role,


### PR DESCRIPTION
i didn't realize previously that it was intentional on our part to mimic the behavior of ArcGIS Online by writing a cookie which codes the username as an email.

this PR:
* reverts that behavior
* uses the information to create a fully hydrated `UserSession` from a cookie.

verified fix manually in opendata-admin. next time i'll do that _before_ i jump into tagging a release. 