### PR TITLE
Ensure the Auth Manager has the full, correct portal url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic
 Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- `session.authMgr.portal` will now be the full ssl org portal url, using the ports and paths from the portalSelf hash
 
 ## [1.1.6]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic
 Versioning](http://semver.org/).
 
-## [Unreleased]
-### Fixed
+## [2.0.0]
+### Breaking Change
 - `session.authMgr.portal` will now be the full ssl org portal url, using the ports and paths from the portalSelf hash
 
 ## [1.1.6]

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Example usage
 | `isInOrg('orgId')` | bool | is the current user a member of the specified org |
 | `isInAnyOrg(['orgId1', 'orgId2'])` | bool | is the current user a member of any of the specified orgs |
 | `portalHostName()` | string | returns a protocol-less hostname for the portal i.e. `www.arcgis.com` or `dcdev.maps.arcgis.com` |
+| `portalRestUrl()` | string | returns https url for the portal api i.e. `https://www.arcgis.com/sharing/rest` or `https://dcdev.maps.arcgis.com/sharing/rest`. Respects ArcGIS Enterprise httpsPort settings |
 
 Example Usage
 

--- a/addon/mixins/gatekeeper.js
+++ b/addon/mixins/gatekeeper.js
@@ -185,6 +185,9 @@ export default Mixin.create({
     return result;
   }),
 
+  /**
+   * Return the full url to the Portal's REST API
+   */
   portalRestUrl: computed('isAuthenticated', function () {
     let result;
     if (this.get('isAuthenticated')) {

--- a/addon/mixins/gatekeeper.js
+++ b/addon/mixins/gatekeeper.js
@@ -173,7 +173,7 @@ export default Mixin.create({
   /**
    * Returns a protocol-less hostname for the Portal
    */
-  portalHostname: computed('isAuthenticated', function () {
+  portalHostname: computed('isAuthenticated', 'portal', function () {
     let result;
     if (this.get('isAuthenticated')) {
       result = getPortalHostname(this.get('portal'));
@@ -188,7 +188,7 @@ export default Mixin.create({
   /**
    * Return the full url to the Portal's REST API
    */
-  portalRestUrl: computed('isAuthenticated', function () {
+  portalRestUrl: computed('isAuthenticated', 'portal', function () {
     let result;
     if (this.get('isAuthenticated')) {
       result = getPortalRestUrl(this.get('portal'));

--- a/addon/mixins/gatekeeper.js
+++ b/addon/mixins/gatekeeper.js
@@ -17,7 +17,8 @@ import { debug, warn } from '@ember/debug';
 import { isArray } from '@ember/array';
 import Mixin from '@ember/object/mixin';
 import {
-  getPortalHostname
+  getPortalHostname,
+  getPortalRestUrl
 } from 'torii-provider-arcgis/utils/url-utils';
 
 export default Mixin.create({
@@ -180,6 +181,18 @@ export default Mixin.create({
       const config = getOwner(this).resolveRegistration('config:environment');
       result = config.torii.providers['arcgis-oauth-bearer'].portalUrl;
       result = result.replace(/https?:\/\//, '');
+    }
+    return result;
+  }),
+
+  portalRestUrl: computed('isAuthenticated', function () {
+    let result;
+    if (this.get('isAuthenticated')) {
+      result = getPortalRestUrl(this.get('portal'));
+    } else {
+      const config = getOwner(this).resolveRegistration('config:environment');
+      result = config.torii.providers['arcgis-oauth-bearer'].portalUrl;
+      result = `${this.get('portalHostname')}/sharing/rest`;
     }
     return result;
   }),

--- a/addon/mixins/gatekeeper.js
+++ b/addon/mixins/gatekeeper.js
@@ -16,6 +16,9 @@ import { computed } from '@ember/object';
 import { debug, warn } from '@ember/debug';
 import { isArray } from '@ember/array';
 import Mixin from '@ember/object/mixin';
+import {
+  getPortalHostname
+} from 'torii-provider-arcgis/utils/url-utils';
 
 export default Mixin.create({
 
@@ -172,13 +175,7 @@ export default Mixin.create({
   portalHostname: computed('isAuthenticated', function () {
     let result;
     if (this.get('isAuthenticated')) {
-      const portal = this.get('portal');
-      const urlKey = portal.urlKey;
-      result = portal.portalHostname;
-
-      if (urlKey) {
-        result = `${urlKey}.${portal.customBaseUrl}`;
-      }
+      result = getPortalHostname(this.get('portal'));
     } else {
       const config = getOwner(this).resolveRegistration('config:environment');
       result = config.torii.providers['arcgis-oauth-bearer'].portalUrl;

--- a/addon/utils/url-utils.js
+++ b/addon/utils/url-utils.js
@@ -34,6 +34,10 @@ export function getPortalUrl (portal) {
   return assembleUrl(parts, insertPort);
 }
 
+export function getPortalRestUrl (portal) {
+  return `${getPortalUrl(portal)}/sharing/rest`;
+}
+
 /**
  * Disassemble a url into a hash of parts so we can reason about it
  */

--- a/addon/utils/url-utils.js
+++ b/addon/utils/url-utils.js
@@ -1,0 +1,110 @@
+
+
+/**
+ * Given a portal hash, construct the correct portal hostname
+ */
+export function getPortalHostname (portal) {
+  if (portal.isPortal) {
+    return  portal.portalHostname;
+  } else {
+    return portal.urlKey ? `${portal.urlKey}.${portal.customBaseUrl}` : portal.portalHostname;
+  }
+
+}
+
+/**
+ * Given a portal hash, return the correct full url
+ * accounting for protocol, ports, and possible paths
+ */
+export function getPortalUrl (portal) {
+  let host = getPortalHostname(portal);
+  let insertPort = false;
+  const parts = splitUrl(host);
+  // now check for protocols & ports...
+  if (portal.allSSL || parts.protocol === 'https') {
+    // assign the port regardless of what it is...
+    parts.port = portal.httpsPort
+    parts.protocol = 'https';
+    // only inject if https port is not 443
+    insertPort = portal.httpsPort !== 443;
+  } else {
+    insertPort = parts.port !== 443;
+  }
+
+  return assembleUrl(parts, insertPort);
+}
+
+/**
+ * Disassemble a url into a hash of parts so we can reason about it
+ */
+export function splitUrl (url) {
+  let result = {};
+  if (hasProtocol(url)) {
+    let parts = url.split('://');
+    result.protocol = parts[0];
+    result.location = parts[1];
+  } else if (isProtocolRelative(url)) {
+    result.protocol = 'https';
+    result.location = url.split('//')[1];
+  } else {
+    // let's assume we want to use https
+    result.protocol = 'https';
+    result.location = url;
+  }
+  // host is the location before the / if present...
+  let chk =  getHost(result.location.split('/'));
+  result.host = chk.host;
+  result.path = chk.path;
+
+  if (hasPort(result.host)) {
+    // order matters here...
+    result.port = result.host.split(':')[1];
+    result.host = result.host.split(':')[0];
+  } else {
+    result.port = portFromProtocol(result.protocol);
+  }
+  return result;
+}
+
+/**
+ * Assemble a full url from a hash of parts, optionally forcing a port
+ */
+function assembleUrl (parts, insertPort = false) {
+  let result;
+  if (insertPort) {
+    result = `${parts.protocol}://${parts.host}:${parts.port}`;
+  } else {
+    result = `${parts.protocol}://${parts.host}`;
+  }
+
+  if (parts.path) {
+    result = `${result}/${parts.path}`;
+  }
+  return result;
+}
+
+/**
+ * Helpers
+ */
+function hasProtocol (url) {
+  return /^https?:\/\//.test(url);
+}
+
+function isProtocolRelative (url) {
+  return /^\/\//.test(url);
+}
+
+function portFromProtocol (protocol) {
+  return protocol === 'https' ? 443 : 80;
+}
+
+function hasPort (host) {
+  return /:\d*$/.test(host);
+}
+
+function getHost ([host, ...path]) {
+  return {
+    host,
+    path: path.join('/')
+  };
+}

--- a/app/utils/url-utils.js
+++ b/app/utils/url-utils.js
@@ -1,0 +1,5 @@
+export {
+  getPortalHostname,
+  splitUrl,
+  getPortalUrl
+} from 'torii-provider-arcgis/utils/url-utils';

--- a/tests/dummy/app/routes/application.js
+++ b/tests/dummy/app/routes/application.js
@@ -5,8 +5,26 @@
 
 import Route from '@ember/routing/route';
 import ENV from '../config/environment';
+import { debug } from '@ember/debug';
 export default Route.extend({
-
+  beforeModel() {
+    // try to re-hydrate old sessions
+    // this._initSession();
+  },
+  /**
+   * Initialize the session, picking up identity from either cookie or local storage
+   */
+  _initSession () {
+    return this.get('session').fetch()
+      .then(() => {
+        debug('User has been automatically logged in... ');
+        return {success: true, status: 'authenticated'};
+      })
+      .catch(() => {
+        debug('No cookie/localstorage entry was found, user is anonymous... ');
+        return {success: true, status: 'anonymous'};
+      });
+  },
   actions: {
     accessDenied: function () {
       this.transitionTo('signin');

--- a/tests/unit/utils/url-utils-test.js
+++ b/tests/unit/utils/url-utils-test.js
@@ -1,0 +1,113 @@
+import {
+  getPortalHostname,
+  splitUrl,
+  getPortalUrl
+} from 'dummy/utils/url-utils';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | url utils');
+
+test('constructs portalUrl using urlKey and customBaseUrl', function(assert) {
+  let result = getPortalHostname({urlKey: 'foo', customBaseUrl: 'mapsqa.arcgis.com', portalHostname: 'other.foo.com'});
+  assert.equal(result, 'foo.mapsqa.arcgis.com')
+});
+
+test('returns portalHostname if urlKey not defined', function(assert) {
+  let result = getPortalHostname({customBaseUrl: 'mapsqa.arcgis.com', portalHostname: 'other.foo.com'});
+  assert.equal(result, 'other.foo.com')
+});
+
+test('returns portalHostname if isPortal', function(assert) {
+  let result = getPortalHostname({urlKey: 'wat', isPortal: true, customBaseUrl: 'mapsqa.arcgis.com', portalHostname: 'other.foo.com'});
+  assert.equal(result, 'other.foo.com')
+});
+
+test('returns portalHostname if isPortal', function(assert) {
+  let result = getPortalHostname({urlKey: 'wat', isPortal: true, customBaseUrl: 'mapsqa.arcgis.com', portalHostname: 'other.foo.com'});
+  assert.equal(result, 'other.foo.com')
+});
+
+test('splitUrl full test', function (assert) {
+  let r = splitUrl('https://some.url.com:4652/some-path/thing?q=string&other=12');
+  assert.equal(r.protocol, 'https', 'should parse the protocol');
+  assert.equal(r.port, 4652, 'should get port from url');
+  assert.equal(r.host, 'some.url.com', 'should split out the host');
+  assert.equal(r.path, 'some-path/thing?q=string&other=12', 'should split out the path');
+})
+
+test('splitUrl infers port if not present', function (assert) {
+  let r = splitUrl('https://some.url.com/some-path/thing?q=string&other=12');
+  assert.equal(r.protocol, 'https', 'should parse the protocol');
+  assert.equal(r.port, 443, 'should infer port from protocol');
+  assert.equal(r.host, 'some.url.com', 'should split out the host');
+  assert.equal(r.path, 'some-path/thing?q=string&other=12', 'should split out the path');
+})
+
+test('splitUrl assume https if protocol not present', function (assert) {
+  let r = splitUrl('some.url.com/some-path/thing?q=string&other=12');
+  assert.equal(r.protocol, 'https', 'should assume the protocol is https');
+  assert.equal(r.port, 443, 'should infer port from protocol');
+  assert.equal(r.host, 'some.url.com', 'should split out the host');
+  assert.equal(r.path, 'some-path/thing?q=string&other=12', 'should split out the path');
+})
+
+test('splitUrl assume https if protocol relative', function (assert) {
+  let r = splitUrl('//some.url.com/some-path/thing?q=string&other=12');
+  assert.equal(r.protocol, 'https', 'should assume the protocol is https');
+  assert.equal(r.port, 443, 'should infer port from protocol');
+  assert.equal(r.host, 'some.url.com', 'should split out the host');
+  assert.equal(r.path, 'some-path/thing?q=string&other=12', 'should split out the path');
+})
+
+test('splitUrl returns defaults if just a host is passed', function (assert) {
+  let r = splitUrl('some.url.com');
+  assert.equal(r.protocol, 'https', 'should assume the protocol is https');
+  assert.equal(r.port, 443, 'should infer port from protocol');
+  assert.equal(r.host, 'some.url.com', 'should split out the host');
+  assert.equal(r.path, '', 'should have empty path');
+})
+
+test('splitUrl works for a portalHostname with port and path', function (assert) {
+  let r = splitUrl('some.url.com:7362/someportal');
+  assert.equal(r.protocol, 'https', 'should assume the protocol is https');
+  assert.equal(r.port, 7362, 'should extract the port');
+  assert.equal(r.host, 'some.url.com', 'should split out the host');
+  assert.equal(r.path, 'someportal', 'should have path');
+})
+
+test('getPortalUrl should work for an allSSL AGO portal', function (assert) {
+  let r = getPortalUrl({
+    allSSL: true,
+    isPortal: false,
+    urlKey: 'dcdev',
+    customBaseUrl: 'mapsqa.arcgis.com',
+    portalHostname: 'qaext.arcgis.com',
+    httpsPort:443,
+    httpPort: 80
+  });
+  assert.equal(r, 'https://dcdev.mapsqa.arcgis.com', 'should work for an AGO Org');
+});
+
+test('getPortalUrl should work for an allSSL Enterprise portal', function (assert) {
+  let r = getPortalUrl({
+    allSSL: true,
+    isPortal: true,
+    customBaseUrl: 'mapsqa.arcgis.com',
+    portalHostname: 'some.company.org/myportal',
+    httpsPort:8443,
+    httpPort: 8080
+  });
+  assert.equal(r, 'https://some.company.org:8443/myportal', 'should work for an Enterprise Org');
+});
+
+test('getPortalUrl should work for an Enterprise portal with port in hostname', function (assert) {
+  let r = getPortalUrl({
+    allSSL: false,
+    isPortal: true,
+    customBaseUrl: 'mapsqa.arcgis.com',
+    portalHostname: 'some.company.org:7080/myportal',
+    httpsPort:7443,
+    httpPort: 7080
+  });
+  assert.equal(r, 'https://some.company.org:7443/myportal', 'should work for an Enterprise Org');
+});


### PR DESCRIPTION
We had some incorrect logic in the code that hydrates a `UserSession` such that it only had the `portalHostname` but did not correctly add the protocol, ports, or paths. 

This PR updates that logic, and applies it to `session.portalHostname` and adds `session.portalRestUrl` 

It also adds a mess of tests on the underlying functions that juggle all the urls & json objects.

We *believe* this accounts for Portal's idiosyncrasies, but essentially we have to merge + release + npl-link into Hub, THEN test w/ portal... so - there may be a 2.0.1, 2.0.2...

### Note
I `npm linked` this into hub-ui & admin, tested it against QA and against our dev portal, and 100% of the time the AuthMgr has the correct Url as computed by the EAPS service-mixin.

So - while EAPS still has the check for `authMgr.portal !== correctPortalRestUrl` we are no longer hitting it.

I'd like to merge this, get it released and into the app, and we can leave the double-check in for a while... but eventually, we can rely on `authMgr.portal` to be the url to the root of the rest api