### PR TITLE
Allow custom redirect uri to be path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic
 Versioning](http://semver.org/).
 
 ## Unreleased
+### Changed
+- allow `customRedirectUri` to be a path (i.e. /redirect.html) instead of just a full url. If a path, prepend the current window.location.
+
 
 ## [2.2.1]
 ### Changed

--- a/app/torii-providers/arcgis-oauth-bearer.js
+++ b/app/torii-providers/arcgis-oauth-bearer.js
@@ -112,7 +112,16 @@
     // if you have multiple apps fronted by nginx and you want to centralize
     // the redirects.
     if (this.get('customRedirectUri')) {
+      // get it...
       uri = this.get('customRedirectUri');
+      // if it does not contains a protocol,
+      if (!uri.includes('http')) {
+        // ensure a slash...
+        if (uri[0] !== '/') {
+          uri = `/${uri}`;
+        }
+        uri =`${this._currentBaseUrl()}${uri}`;
+      }
     } else {
       // Set the redirectUri to the redirect.html that's in the addon's public
       // folder and exposed at /<addon-name>/redirect.html

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "torii-provider-arcgis",
   "version": "2.2.1",
-  "description": "ArcGIS authentication provider & adapters for Torii, packaged as an Ember CLI Addon.",
+  "description": "ArcGIS authentication provider & adapters for Torii, packaged as an Ember CLI Addon. ",
   "keywords": [
     "ember-addon",
     "arcgis",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "torii-provider-arcgis",
   "version": "2.2.1",
-  "description": "ArcGIS authentication provider & adapters for Torii, packaged as an Ember CLI Addon. ",
+  "description": "ArcGIS authentication provider & adapters for Torii, packaged as an Ember CLI Addon.",
   "keywords": [
     "ember-addon",
     "arcgis",


### PR DESCRIPTION
Allow the customRedirectUrl to be a path relative to the current application. This was needed for the ArcGIS Hub application, which runs on many different sub-domains and custom domains, which precludes setting a full url.