### PR TITLE
url decode username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic
 Versioning](http://semver.org/).
 
 ## Unreleased
+### Changed
+- url decode username we get back on the url hash
 
 ## [3.0.0]
 

--- a/app/torii-providers/arcgis-oauth-bearer.js
+++ b/app/torii-providers/arcgis-oauth-bearer.js
@@ -159,6 +159,9 @@
       if (missingResponseParams.length) {
         throw new Error(`${debugPrefix} The response from the provider is missing these required response params: ${missingResponseParams.join(', ')}`);
       }
+      // the server sends the username back on the hash url encoded but we should work with it decoded
+      // it will get url encoded again anytime we need to use it in a url
+      authData.username = decodeURIComponent(authData.username);
       // attach in more info that arcgisRest wants
       authData.clientId = clientId;
       authData.portal = portalUrl;

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,1 +1,0 @@
-{"compilerOptions":{"target":"es6","experimentalDecorators":true},"exclude":["node_modules","bower_components","tmp","vendor",".git","dist"]}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,1 @@
+{"compilerOptions":{"target":"es6","experimentalDecorators":true},"exclude":["node_modules","bower_components","tmp","vendor",".git","dist"]}


### PR DESCRIPTION
When we get the username back on the url hash it is url-encoded. We now decode it because it seems to me we want to work with it decoded and only encode it when it needs to be used to create a url.

This came up because we got a [bug](https://esriarlington.tpondemand.com/entity/90714-regression-unable-to-sign-in-if). They say this worked until recently. I suspect that it stopped working because of the switch to using AGRjs because AGRjs url encodes what gets passed to it.

If you url endode `svadlamani@ess` you get `svadlamani%40ess` but if you encode that again you get `svadlamani%2540ess`  which is no good.