### PR TITLE
handle redirectUriQueryString option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic
 Versioning](http://semver.org/).
 
+## Unreleased
+### Added
+- `arcgis-oath-bearer::open` handles `redirectUriQueryString` option by appending it to the redirectUri
+
 ## [3.1.0]
 ### Changed
 - url decode username we get back on the url hash

--- a/app/torii-providers/arcgis-oauth-bearer.js
+++ b/app/torii-providers/arcgis-oauth-bearer.js
@@ -135,6 +135,12 @@
       }
     }
 
+    if (options.redirectUriQueryString) {
+      // redirectUriQueryString allows us to pass queryParams through to the consuming app to be handled after login
+      const separator = uri.includes('?') ? '&' : '?';
+      uri = `${uri}${separator}${options.redirectUriQueryString}`;
+    }
+
     this.set('redirectUri', uri);
 
     let name = this.get('name');

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,1 @@
+{"compilerOptions":{"target":"es6","experimentalDecorators":true},"exclude":["node_modules","bower_components","tmp","vendor",".git","dist"]}


### PR DESCRIPTION
`arcgis-oath-bearer::open` handles `redirectUriQueryString` option by appending it to the redirectUri so that it can be read by the consuming app after login.

See my comment on https://esriarlington.tpondemand.com/entity/112619-user-has-to-select-follow-star