### PR TITLE
Handle undefined user.privileges

### DIFF
--- a/addon/mixins/gatekeeper.js
+++ b/addon/mixins/gatekeeper.js
@@ -80,7 +80,8 @@ export default Mixin.create({
   hasPrivilege (privilege) {
     let user = this.get('currentUser');
     if (user) {
-      return (user.privileges.indexOf(privilege) > -1);
+      let privs = user.privileges || [];
+      return (privs.indexOf(privilege) > -1);
     } else {
       return false;
     }

--- a/tests/unit/mixins/gatekeeper-test.js
+++ b/tests/unit/mixins/gatekeeper-test.js
@@ -87,6 +87,20 @@ test('hasPrivilege', function (assert) {
   assert.notOk(subject.isInRole('other:fake'));
 });
 
+test('hasPrivilege support public users w/o priv array', function (assert) {
+  let GatekeeperObject = EmberObject.extend(GatekeeperMixin);
+  let subject = GatekeeperObject.create();
+  let user = {
+    username: 'fakeuser',
+  };
+  subject.set('currentUser', user);
+  assert.expect(4);
+  assert.notOk(subject.hasPrivilege('fake:one'));
+  assert.notOk(subject.hasPrivilege('fake:two'));
+  assert.notOk(subject.hasPrivilege('fake:three'));
+  assert.notOk(subject.isInRole('other:fake'));
+});
+
 test('hasAnyPrivilege', function (assert) {
   let GatekeeperObject = EmberObject.extend(GatekeeperMixin);
   let subject = GatekeeperObject.create();


### PR DESCRIPTION
Turns out... public user accounts... simply don't have the .privileges property. 

O_O