### PR TITLE
F/enable platform self portal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic
 Versioning](http://semver.org/).
 
+## UNRELEASED
+
+### Changed
+
+- added support for esri_aopc cookie in ArcGIS Enterprise (will only work on 10.9+, but should not error on downlevel)
+
 ## [4.0.1]
 
 ### Fixed

--- a/app/torii-adapters/arcgis-oauth-bearer.js
+++ b/app/torii-adapters/arcgis-oauth-bearer.js
@@ -485,8 +485,7 @@ export default EmberObject.extend({
 
   /**
    * The encrypted platform cookie is not accessible from javascript
-   * so if we are on *.arcgis.com, we just shoot this off, and it may
-   * or may not return with a token.
+   * so we just shoot this off, and it may or may not return with a token.
    * @param {*} clientId
    * @param {*} portal
    * @param {*} redirectUri
@@ -496,32 +495,27 @@ export default EmberObject.extend({
       valid: false,
       properties: {}
     };
-    // If the redirect uri is  not on *.arcgis.com we don't bother
-    if (redirectUri.indexOf('.arcgis.com') === -1) {
-      return Promise.resolve(result);
-    } else {
-      return platformSelf(clientId, redirectUri, portal)
-      .then((response) => {
-        const currentTimestamp = new Date().getTime();
-        const tokenExpiresTimestamp = currentTimestamp + (response.expires_in * 1000);
-        // Construct the session and return it
-        result.properties = {
-          portal: response.portalUrl,
-          clientId,
-          username: response.username,
-          token: response.token,
-          expires: tokenExpiresTimestamp,
-          ssl: true
-        };
-        result.valid = true;
-        return result;
-      })
-      .catch((err) => {
-        debug(`torii.adapter._tryEncryptedCookie: ${err}. Returning no auth`);
-        return result;
-      });
-    }
 
+    return platformSelf(clientId, redirectUri, portal)
+    .then((response) => {
+      const currentTimestamp = new Date().getTime();
+      const tokenExpiresTimestamp = currentTimestamp + (response.expires_in * 1000);
+      // Construct the session and return it
+      result.properties = {
+        portal: response.portalUrl,
+        clientId,
+        username: response.username,
+        token: response.token,
+        expires: tokenExpiresTimestamp,
+        ssl: true
+      };
+      result.valid = true;
+      return result;
+    })
+    .catch((err) => {
+      debug(`torii.adapter._tryEncryptedCookie: ${err}. Returning no auth`);
+      return result;
+    });
   }
 
 });


### PR DESCRIPTION
Prior to this we limited this to scenarios where the redirect uri ended with *.arcgis.com - but that precluded Enterprise, which now supports platformSelf.

This removes that gating