### PR TITLE
fix: add expires_in into response

### DIFF
--- a/app/torii-adapters/arcgis-oauth-bearer.js
+++ b/app/torii-adapters/arcgis-oauth-bearer.js
@@ -525,6 +525,7 @@ export default EmberObject.extend({
           username: username,
           token: etResponse.token,
           expires: tokenExpiresTimestamp,
+          expires_in: etResponse.expires_in,
           ssl: true,
         };
         result.valid = true;


### PR DESCRIPTION
Back-ports a change that's in the main branch, but which we can't use in Hub b/c we're still on rest-js 3.x